### PR TITLE
Add methods for removing values and clearing all storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The reverse is also true. This means that an atom modified in a tab
 (alandipert.storage-atom/remove-local-storage! :prefs) ;; remove single value
 (alandipert.storage-atom/clear-local-storage!)         ;; clear all values
 
+;; Note: clearing a value will reset it to the initial value of the atom passed
+;; to `local-storage`, not nil. This is probably what you want.
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ The reverse is also true. This means that an atom modified in a tab
 ;; Check that current value has been stored in localStorage.
 
 (.getItem js/localStorage ":prefs") ;=> "{:bg-color \"red\"}"
+
+;; To remove an item or clear all storage, use the provided methods instead
+;; of calling the js method. This ensures that affected atoms are updated.
+
+(alandipert.storage-atom/remove-local-storage! :prefs) ;; remove single value
+(alandipert.storage-atom/clear-local-storage!)         ;; clear all values
+
 ```
 
 ## Notes

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject alandipert/storage-atom "1.2.3"
+(defproject ninjudd/storage-atom "1.2.4-beta"
   :description "ClojureScript atoms backed by HTML5 web storage."
   :url "https://github.com/alandipert/storage-atom"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
I read through the discussion in #5, and I think this implementation addresses all the concerns there, though I took a different approach.

I use the existing storage event listener, and fire a synthetic event so that `remove-local-storage!` and `clear-local-storage!` affect the current window in addition to other windows. This allows me to support clearing all values, and avoids duplicate code for handling remove in the current window and other windows.

This also fixes a bug where clear StorageEvents (empty key) were ignored.

Also, I found that in all of my use cases, I need the atom to be reset not to nil when it is cleared/removed, but to the original value of the atom provided to `local-storage`. So I implemented that too.