### PR TITLE
Add try catch around maybe-update-backend

### DIFF
--- a/src/cljs/alandipert/storage_atom.cljs
+++ b/src/cljs/alandipert/storage_atom.cljs
@@ -59,12 +59,14 @@ discarded an only the new one is committed."
     (if (empty? (.-key e)) ;; is all storage is being cleared?
       (binding [*watch-active* false]
         (reset! atom default))
-      (when-let [sk (cljson->clj (.-key e))]
+      (try 
+        (when-let [sk (cljson->clj (.-key e))]
         (when (= sk k) ;; is the stored key the one we are looking for?
           (binding [*watch-active* false]
             (reset! atom (if-let [value (.-newValue e)] ;; new value, or is key being removed?
                            (cljson->clj value)
-                           default))))))))
+                           default)))))
+        (catch :default e)))))
 
 (defn link-storage
   [atom storage k]


### PR DESCRIPTION
Hi I am getting javascript errors when an externel element in my page updates the local storage.
As the StorageEvent's key is a string value cljson->clj throws a syntax error.

This patch fixes this.