### PR TITLE
Adds atoms for transit handlers

### DIFF
--- a/src/alandipert/storage_atom.cljs
+++ b/src/alandipert/storage_atom.cljs
@@ -3,11 +3,16 @@
             [goog.Timer :as timer]
             [clojure.string :as string]))
 
+
+(def transit-read-handlers (atom {}))
+
+(def transit-write-handlers (atom {}))
+
 (defn clj->json [x]
-  (t/write (t/writer :json) x))
+  (t/write (t/writer :json {:handlers @transit-write-handlers}) x))
 
 (defn json->clj [x]
-  (t/read (t/reader :json) x))
+  (t/read (t/reader :json {:handlers @transit-read-handlers}) x))
 
 (defprotocol IStorageBackend
   "Represents a storage resource."


### PR DESCRIPTION
Adds atoms for transit's read and write handlers, similar to how `storage-delay` is configured.

A solution for #12.

Feel free to not merge this pull request if you want to solve the problem another way.