### PR TITLE
Update transit-cljs

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,7 +4,7 @@
                   [adzerk/boot-cljs            "1.7.48-3"        :scope "test"]
                   [adzerk/bootlaces            "0.1.10"          :scope "test"]
                   [crisptrutski/boot-cljs-test "0.2.0-SNAPSHOT" :scope "test"]
-                  [com.cognitect/transit-cljs  "0.8.225"]]
+                  [com.cognitect/transit-cljs  "0.8.243"]]
   :source-paths #{"test"}
   :resource-paths #{"src"})
 


### PR DESCRIPTION
This is to avoid following warnings when used with Clojure 1.9. 

```
WARNING: uri? already refers to: cljs.core/uri? being replaced by: cognitect.transit/uri? at line 332 target/resources/public/js/cognitect/transit.cljs
WARNING: uuid? already refers to: cljs.core/uuid? being replaced by: cognitect.transit/uuid? at line 342 target/resources/public/js/cognitect/transit.cljs
```
I have run tests locally and they pass.