### PR TITLE
Refactor tests improving coverage

### DIFF
--- a/test/alandipert/storage_atom/test.cljs
+++ b/test/alandipert/storage_atom/test.cljs
@@ -1,44 +1,84 @@
 (ns alandipert.storage-atom.test
-  (:require [alandipert.storage-atom :refer [local-storage]]
+  (:require [alandipert.storage-atom
+             :refer [clear-local-storage! clj->json dispatch-synthetic-event!
+                     load-local-storage local-storage remove-local-storage!
+                     *storage-delay*]]
+            [alandipert.storage-atom.test.macros
+             :refer-macros [with-local-storage-testing-scope]]
             [cljs.test :refer-macros [deftest is testing run-tests]]))
 
-;;; localStorage tests
+(deftest test-local-storage-life-cycle
+  (with-local-storage-testing-scope
+    (let [a1 (local-storage (atom {:x 1}) "foo")]
+      (testing "Initialization to given value"
+        (is (= @a1 {:x 1}))
+        (is (= (load-local-storage "foo") {:x 1})))
+      (testing "Ordinary update"
+        (swap! a1 assoc :x 10)
+        (is (= @a1 {:x 10}))
+        (is (= (load-local-storage "foo") {:x 10})))
+      (testing "Update with no actual change"
+        (reset! a1 {:x 10})
+        (is (= @a1 {:x 10}))
+        (is (= (load-local-storage "foo") {:x 10})))
+      (testing "Collection types preserved"
+        (swap! a1 assoc :ys [#{1 2 3}])
+        (is (= @a1 {:x 10 :ys [#{1 2 3}]}))
+        (is (= (load-local-storage "foo") {:x 10 :ys [#{1 2 3}]})))
+      (let [a2 (local-storage (atom nil) "foo")]
+        (testing "Initialization to persisted value"
+          (is (= @a2 {:x 10 :ys [#{1 2 3}]}))
+          (is (= (load-local-storage "foo") {:x 10 :ys [#{1 2 3}]})))
+        (testing "Update propagation"
+          (swap! a2 dissoc :ys)
+          (is (= (load-local-storage "foo") {:x 10}))
+          (is (= @a2 {:x 10}))
+          ;; Simulating the resulting event synchronously here
+          (dispatch-synthetic-event! js/localStorage
+                                     (clj->json "foo")
+                                     (clj->json {:x 10}))
+          (is (= @a1 {:x 10})))
+        (testing "Reset to initial values upon clearing storage"
+          (clear-local-storage!)
+          (is (= @a1 {:x 1}))
+          ;; This is exactly correct but not sure if intended
+          (is (= @a2 nil))
+          (is (= (load-local-storage "foo") nil)))))))
 
-(def a1 (local-storage (atom {}) "k1"))
-(deftest test-swap
-  (swap! a1 assoc :x 10)
-  (is (= (:x @a1) 10)))
-
-(def cnt (atom 0))
-(deftest test-watch
-  (add-watch a1 :x (fn [_ _ _ _] (swap! cnt inc)))
-  (reset! a1 {})
-  (swap! a1 assoc "computers" "rule")
-  (is (= 2 @cnt)))
-
-(def a2 (local-storage (atom 0 :validator even?) :foo))
-(deftest test-validation
-  (is (= @a2 0)))
-
-;;; Can't test the 'update' event, because it's only fired
-;;; when changes come from another window.
-
-(def a3 (local-storage
-         (atom {:x {:y {:z 42}}} :meta {:some :metadata}) "k3"))
-
-(deftest test-update
-  (is (= (get-in @a3 [:x :y :z]) 42))
-  (is (= (:some (meta a3)) :metadata)))
-
-
-(def a4 (local-storage
-         (atom {:xs [1 2 3]})
-         "k4"))
-
-(deftest test-collection-types-preserved
-  (swap! a4 update :xs conj 4)
-  (is (= (peek (get @a4 :xs)) 4))
-  (swap! a4 assoc :ys [#{1 2 3}])
-  (is (vector? (get @a4 :ys)))
-  (is (set? (first (get @a4 :ys))))
-  (is (= (get a4 :ys [#{1 2 3}]))))
+(deftest test-local-storage-isolation
+  (with-local-storage-testing-scope
+    (let [foo (local-storage (atom {:x 1}) :foo)
+          bar (local-storage (atom {:y 2}) :bar)]
+      (testing "Initial state is good"
+        (is (= (load-local-storage :foo) {:x 1}))
+        (is (= (load-local-storage :bar) {:y 2})))
+      (testing "Updates don't interfere"
+        (swap! foo assoc :y 3)
+        (swap! bar assoc :x 4)
+        (is (= @foo {:x 1 :y 3}))
+        (is (= @bar {:x 4 :y 2}))
+        (is (= (load-local-storage :foo) {:x 1 :y 3}))
+        (is (= (load-local-storage :bar) {:x 4 :y 2})))
+      (testing "Removing single key doesn't interfere"
+        (remove-local-storage! :foo)
+        (is (= @foo {:x 1}))
+        (is (= @bar {:x 4 :y 2}))
+        (is (= (load-local-storage :foo) nil))
+        (is (= (load-local-storage :bar) {:x 4 :y 2}))
+        (swap! foo assoc :y 5)
+        (remove-local-storage! :bar)
+        (is (= @foo {:x 1 :y 5}))
+        (is (= @bar {:y 2}))
+        (is (= (load-local-storage :foo) {:x 1 :y 5}))
+        (is (= (load-local-storage :bar) nil))
+        (swap! bar assoc :x 6)
+        (is (= @foo {:x 1 :y 5}))
+        (is (= @bar {:x 6 :y 2}))
+        (is (= (load-local-storage :foo) {:x 1 :y 5}))
+        (is (= (load-local-storage :bar) {:x 6 :y 2})))
+      (testing "Clearing local storage removes everything"
+        (clear-local-storage!)
+        (is (= @foo {:x 1}))
+        (is (= @bar {:y 2}))
+        (is (= (load-local-storage :foo) nil))
+        (is (= (load-local-storage :bar) nil))))))

--- a/test/alandipert/storage_atom/test/macros.cljc
+++ b/test/alandipert/storage_atom/test/macros.cljc
@@ -1,0 +1,7 @@
+(ns alandipert.storage-atom.test.macros)
+
+(defmacro with-local-storage-testing-scope
+  [& body]
+  `(binding [alandipert.storage-atom/*storage-delay* :none]
+     ~@body
+     (.clear js/localStorage)))


### PR DESCRIPTION
Hi, Alan! While trying to do some other modifiations to the library I realized that the existing tests didn't cover the actual interaction with the local storage. So this PR aims to fix that. In particular this PR:

- Adds support for immediate execution of the storage operation.
- Adds support for generating synthetic storage update events (in addition to generating just the remove events).
- Refactors the tests to cover the actual storage operations against the local storage (still leaving the session storage outside the coverage)