### PR TITLE
Pre post cleanup callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,14 @@ committed). It can be modified with the `storage-delay` atom or the
 
 It's possible to modify the contents of the atom on the way into storage
 and back out again using the optional arguments `pre-clean-fn` and
-`post-clean-fn`. Both are a function that takes the value and transforms
-is a) before persisting and b) after restore but before swapping back in.
+`post-clean-fn`.
+
+ * `pre-clean-fn` takes a single argument which is the value on the way
+ to being saved.
+ * `post-clean-fn` takes two arguments. The first is the value as it
+ comes out of storage. The second is the previous value (if any). You
+ can use this to merge the existing state with the state coming out of
+ storage.
 
 
 [enduro](https://github.com/alandipert/enduro) is a Clojure library

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ committed). It can be modified with the `storage-delay` atom or the
 ```
 
 
+It's possible to modify the contents of the atom on the way into storage
+and back out again using the optional arguments `pre-clean-fn` and
+`post-clean-fn`. Both are a function that takes the value and transforms
+is a) before persisting and b) after restore but before swapping back in.
+
+
 [enduro](https://github.com/alandipert/enduro) is a Clojure library
 that provides similar functionality by using files or a database for
 storage.

--- a/src/alandipert/storage_atom.cljs
+++ b/src/alandipert/storage_atom.cljs
@@ -23,7 +23,7 @@
   IStorageBackend
   (-get [_this not-found]
     (if-let [existing (.getItem store (clj->json key))]
-      ((or post-clean-fn identity) (json->clj existing))
+      ((or post-clean-fn identity) (json->clj existing) nil)
       not-found))
   (-commit! [_this value]
     (.setItem store (clj->json key) (clj->json ((or pre-clean-fn identity) value)))))
@@ -77,7 +77,7 @@ discarded an only the new one is committed."
             (binding [*watch-active* false]
               (reset! atom (let [value (.-newValue e)] ;; new value, or is key being removed?
                              (if-not (string/blank? value)
-                               ((or post-clean-fn identity) (json->clj value))
+                               ((or post-clean-fn identity) (json->clj value) @atom)
                                default))))))
         (catch :default _e)))))
 

--- a/src/alandipert/storage_atom.cljs
+++ b/src/alandipert/storage_atom.cljs
@@ -21,11 +21,11 @@
 
 (deftype StorageBackend [store key]
   IStorageBackend
-  (-get [this not-found]
+  (-get [_this not-found]
     (if-let [existing (.getItem store (clj->json key))]
       (json->clj existing)
       not-found))
-  (-commit! [this value]
+  (-commit! [_this value]
     (.setItem store (clj->json key) (clj->json value))))
 
 
@@ -79,7 +79,7 @@ discarded an only the new one is committed."
                              (if-not (string/blank? value)
                                (json->clj value)
                                default))))))
-        (catch :default e)))))
+        (catch :default _e)))))
 
 (defn link-storage
   [atom storage k]


### PR DESCRIPTION
Hi Alan,

Thanks very much for storage-atom, I have used it a whole bunch in the last few years.

This patch adds two optional callback functions `pre-clean-fn` and `post-clean-fn`. These callbacks allow the user to clean the value before it is written to storage and on the way out after it is read from storage. The first callback takes the value and the second one takes the outgoing value and it's previous value (if any). If there is anything you want me to do or if I can improve this patch in any way do let me know.

PS I was not able to run the tests using `boot test-cljs` as an error occurred: `java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(cljs/closure.clj:1:1)`

Fixes #20.